### PR TITLE
Add reload to Picture#update_likes

### DIFF
--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -4,13 +4,14 @@ class Picture < ActiveRecord::Base
 
   def update_likes(user)
     user_liked?(user) ? unlike(user) : like(user)
+    reload
   end
 
   def likes_message(user)
-    if ajax_fail || !user_liked?(user)
-      "<strong>#{self.likes.count} people</strong> like this image".html_safe
-    else
+    if user_liked?(user)
       "<strong>You</strong> and <strong>#{self.likes.count - 1} other people</strong> like this image".html_safe
+    else
+      "<strong>#{self.likes.count} people</strong> like this image".html_safe
     end
   end
 
@@ -24,23 +25,15 @@ class Picture < ActiveRecord::Base
 
   private
 
-      def user_liked?(user)
-        self.likes.any? do |like| 
-          like.user_id == user.id 
-        end
-      end
+  def user_liked?(user)
+    likes.any? { |like| like.user_id == user.id }
+  end
 
-      def like(user)
-        self.likes.create(user_id: user.id)
-      end
+  def like(user)
+    likes.create(user_id: user.id)
+  end
 
-      def unlike(user)
-        self.likes.find_by(user_id: user.id).destroy
-      end
-
-      def ajax_fail
-        # fixes error that occurs when user_liked? is called with ajax
-        self.likes.count != self.likes.length
-      end
-
+  def unlike(user)
+    likes.find_by(user_id: user.id).destroy
+  end
 end

--- a/app/models/picture.rb
+++ b/app/models/picture.rb
@@ -9,9 +9,9 @@ class Picture < ActiveRecord::Base
 
   def likes_message(user)
     if user_liked?(user)
-      "<strong>You</strong> and <strong>#{self.likes.count - 1} other people</strong> like this image".html_safe
+      "<strong>You</strong> and <strong>#{likes.count - 1} other people</strong> like this image".html_safe
     else
-      "<strong>#{self.likes.count} people</strong> like this image".html_safe
+      "<strong>#{likes.count} people</strong> like this image".html_safe
     end
   end
 


### PR DESCRIPTION
Updating a picture's likes did not refresh the model's associations in memory. This meant that the `#user_liked?` logic failed, which I think is what the `#ajax_fail` method was attempting to address. 

However, it wasn't included in `#heart_class`, which meant that views rendered through ajax requests to remove a `like` incorrectly assigned a red heart class.

In other words, if a user un-liked a picture, the picture was removed from the user's likes, but the user was not removed from the picture's likes. `#ajax_fail` provided a work around for `#likes_message`, but not for `#heart_class`.

Reloading the picture in memory when `#update_likes` is called corrects this, making `#ajax_fail` unnecessary.
